### PR TITLE
Fix unsupported bitmap type.

### DIFF
--- a/adafruit_cursorcontrol/cursorcontrol.py
+++ b/adafruit_cursorcontrol/cursorcontrol.py
@@ -78,7 +78,7 @@ class Cursor(object):
             self._cursor_bitmap = self._default_cursor_bitmap()
         else:
             self._cursor_bitmap = bmp
-        self.generate_cursor(bmp)
+        self.generate_cursor(self._cursor_bitmap)
     # pylint: enable=too-many-arguments,line-too-long
 
     def __enter__(self):


### PR DESCRIPTION
Fixes an issue where only `bmp` object is set-able within `init`'s `generate_cursor`, not allowing for a generated default cursor type. 

Ref: https://github.com/adafruit/Adafruit_CircuitPython_CursorControl/issues/8