### PR TITLE
Fix Pybadge no attribute error

### DIFF
--- a/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
+++ b/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
@@ -41,7 +41,7 @@ PYBADGE_BUTTON_RIGHT = const(16)
 # PyBadge & PyGamer
 PYBADGE_BUTTON_A = const(2)
 
-class CursorManager(object):
+class CursorManager():
     """Simple interaction user interface interaction for Adafruit_CursorControl.
 
     :param adafruit_cursorcontrol cursor: The cursor object we are using.

--- a/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
+++ b/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
@@ -51,8 +51,6 @@ class CursorManager(object):
         self._cursor = cursor
         self._is_clicked = False
         self._init_hardware()
-        self._center_x = self._joystick_x.value
-        self._center_y = self._joystick_y.value
 
     def __enter__(self):
         return self
@@ -89,6 +87,9 @@ class CursorManager(object):
             self._joystick_x = analogio.AnalogIn(board.JOYSTICK_X)
             self._joystick_y = analogio.AnalogIn(board.JOYSTICK_Y)
             self._pad_btns = {"btn_a": PYBADGE_BUTTON_A}
+            # Sample the center points of the joystick
+            self._center_x = self._joystick_x.value
+            self._center_y = self._joystick_y.value
         else:
             raise AttributeError(
                 "Board must have a D-Pad or Joystick for use with CursorManager!"


### PR DESCRIPTION
Joystick is not shared between the PyBadge and PyGamer. Sampling the joystick's center moved out of `__init__` to `init_hardware`'s pygamer-specific initialization. 

Fixes https://github.com/adafruit/Adafruit_CircuitPython_CursorControl/issues/11