### PR TITLE
Remove max_size parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Introduction
 ============
 
-.. image:: https://readthedocs.org/projects/adafruit-circuitpython-cursorcontrol/badge/?version=latest
+.. image:: https://readthedocs.org/projects/cursorcontrol/badge/?version=latest
     :target: https://circuitpython.readthedocs.io/projects/cursorcontrol/en/latest/
     :alt: Documentation Status
 

--- a/adafruit_cursorcontrol/cursorcontrol.py
+++ b/adafruit_cursorcontrol/cursorcontrol.py
@@ -44,7 +44,7 @@ class Cursor:
         display = board.DISPLAY
 
         # Create the display context
-        splash = displayio.Group(max_size=22)
+        splash = displayio.Group()
 
         # initialize the mouse cursor object
         mouse_cursor = Cursor(display, display_group=splash)
@@ -227,7 +227,7 @@ class Cursor:
     def generate_cursor(self, bmp):
         """Generates a cursor icon"""
         self._is_deinited()
-        self._cursor_grp = displayio.Group(max_size=1, scale=self._scale)
+        self._cursor_grp = displayio.Group(scale=self._scale)
         self._cur_palette = displayio.Palette(3)
         self._cur_palette.make_transparent(0)
         self._cur_palette[1] = 0xFFFFFF

--- a/adafruit_cursorcontrol/cursorcontrol.py
+++ b/adafruit_cursorcontrol/cursorcontrol.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-`adafruit_cursorcontrol`
+`adafruit_cursorcontrol.cursorcontrol`
 ================================================================================
 
 Mouse cursor for interaction with CircuitPython UI elements.
@@ -23,7 +23,7 @@ Implementation Notes
 import displayio
 
 __version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Cursor.git"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_CursorControl.git"
 
 
 class Cursor:

--- a/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
+++ b/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-`adafruit_cursorcontrol_cursormanager`
+`adafruit_cursorcontrol.cursorcontrol_cursormanager`
 ================================================================================
 Simple interaction user interface interaction for Adafruit_CursorControl.
 * Author(s): Brent Rubell

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,4 +1,5 @@
-API
-====
-.. automodule:: adafruit_cursorcontrol
+.. automodule:: adafruit_cursorcontrol.cursorcontrol
+   :members:
+
+.. automodule:: adafruit_cursorcontrol.cursorcontrol_cursormanager
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["displayio"]
+autodoc_mock_imports = ["displayio", "gamepadshift"]
 
 
 intersphinx_mapping = {

--- a/examples/cursorcontrol_buttons_text.py
+++ b/examples/cursorcontrol_buttons_text.py
@@ -14,7 +14,7 @@ from adafruit_cursorcontrol.cursorcontrol_cursormanager import CursorManager
 display = board.DISPLAY
 
 # Create the display context
-splash = displayio.Group(max_size=22)
+splash = displayio.Group()
 
 # Use the built-in system font
 font = terminalio.FONT

--- a/examples/cursorcontrol_custom_cursor.py
+++ b/examples/cursorcontrol_custom_cursor.py
@@ -11,7 +11,7 @@ from adafruit_cursorcontrol.cursorcontrol_cursormanager import CursorManager
 display = board.DISPLAY
 
 # Create the display context
-splash = displayio.Group(max_size=5)
+splash = displayio.Group()
 
 # initialize the mouse cursor object
 bmp = displayio.Bitmap(20, 20, 3)

--- a/examples/cursorcontrol_simpletest.py
+++ b/examples/cursorcontrol_simpletest.py
@@ -11,7 +11,7 @@ from adafruit_cursorcontrol.cursorcontrol_cursormanager import CursorManager
 display = board.DISPLAY
 
 # Create the display context
-splash = displayio.Group(max_size=5)
+splash = displayio.Group()
 
 # initialize the mouse cursor object
 mouse_cursor = Cursor(display, display_group=splash)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
+adafruit-circuitpython-debouncer

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=["Adafruit-Blinka", "no"],
+    install_requires=["Adafruit-Blinka"],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=["Adafruit-Blinka"],
+    install_requires=["Adafruit-Blinka", "adafruit-circuitpython-debouncer"],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

Update the `requirements.txt` and `setup.py` so that `pip` can install it.

Modify the docs, so that the API docs build. Note: the docs have not been checked for validity.

**This has not been tested** - it needs `gamepadshift` and I don't have a suitable device:
https://circuitpython.readthedocs.io/en/latest/shared-bindings/support_matrix.html?filter=gamepadshift