### PR TITLE
Remove usage of max_glyphs with Label

### DIFF
--- a/examples/cursorcontrol_buttons_text.py
+++ b/examples/cursorcontrol_buttons_text.py
@@ -102,14 +102,10 @@ text_label = label.Label(
 )
 splash.append(text_label)
 
-text_speed = label.Label(
-    font, max_glyphs=15, color=0x00FF00, x=LBL_TEXT[0], y=LBL_TEXT[1]
-)
+text_speed = label.Label(font, color=0x00FF00, x=LBL_TEXT[0], y=LBL_TEXT[1])
 splash.append(text_speed)
 
-text_scale = label.Label(
-    font, max_glyphs=15, color=0x00FF00, x=LBL_TEXT[0], y=LBL_TEXT[1] + 20
-)
+text_scale = label.Label(font, color=0x00FF00, x=LBL_TEXT[0], y=LBL_TEXT[1] + 20)
 splash.append(text_scale)
 
 # initialize the mouse cursor object


### PR DESCRIPTION
Remove usage of `max_glyphs` now that it has been removed from `Adafruit_CircuitPython_Display_Text`
https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/releases/tag/2.20.0

**Not tested**: I don't have any hardware which uses `gamepadshift` - needed for the changed example.