### PR TITLE
Remove gamepad, swap with keypad

### DIFF
--- a/adafruit_cursorcontrol/__init__.py
+++ b/adafruit_cursorcontrol/__init__.py
@@ -1,7 +1,14 @@
 # SPDX-FileCopyrightText: 2019 Brent Rubell for Adafruit Industries
 #
 # SPDX-License-Identifier: MIT
+"""
+`adafruit_cursorcontrol.cursorcontrol_cursormanager`
+================================================================================
+Mouse cursor for interaction with CircuitPython UI elements
 
+* Author(s): Brent Rubell
+
+"""
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_CursorControl.git"
 

--- a/adafruit_cursorcontrol/__init__.py
+++ b/adafruit_cursorcontrol/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2019 Brent Rubell for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+

--- a/adafruit_cursorcontrol/__init__.py
+++ b/adafruit_cursorcontrol/__init__.py
@@ -11,4 +11,3 @@ Mouse cursor for interaction with CircuitPython UI elements
 """
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_CursorControl.git"
-

--- a/adafruit_cursorcontrol/__init__.py
+++ b/adafruit_cursorcontrol/__init__.py
@@ -2,3 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_CursorControl.git"
+

--- a/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
+++ b/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
@@ -11,7 +11,7 @@ Simple interaction user interface interaction for Adafruit_CursorControl.
 import board
 from micropython import const
 import analogio
-from keypad import ShiftRegisterKeys
+from keypad import ShiftRegisterKeys, Event
 from adafruit_debouncer import Debouncer
 
 __version__ = "0.0.0-auto.0"
@@ -37,7 +37,7 @@ class CursorManager:
         self._cursor = cursor
         self._is_clicked = False
         self._pad_states = 0
-        self._event = None
+        self._event = Event()
         self._init_hardware()
 
     def __enter__(self):

--- a/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
+++ b/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
@@ -83,11 +83,11 @@ class CursorManager:
                 "Board must have a D-Pad or Joystick for use with CursorManager!"
             )
         self._pad = ShiftRegisterKeys(
-            clock = board.BUTTON_CLOCK,
-            data = board.BUTTON_OUT,
-            latch = board.BUTTON_LATCH,
+            clock=board.BUTTON_CLOCK,
+            data=board.BUTTON_OUT,
+            latch=board.BUTTON_LATCH,
             key_count=8,
-            value_when_pressed=True
+            value_when_pressed=True,
         )
 
     @property
@@ -134,12 +134,12 @@ class CursorManager:
     def _store_button_states(self, event):
         """Stores the state of the PyBadge's D-Pad or the PyGamer's Joystick
         into a byte
-        
+
         :param Event event: The latest button press transition event detected.
         """
         if event:
             bit_index = event.key_number
-            current_state = (self._pad_states >> bit_index)
+            current_state = self._pad_states >> bit_index
             if current_state != event.pressed:
                 self._pad_states = (1 << bit_index) ^ self._pad_states
 

--- a/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
+++ b/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
@@ -52,6 +52,7 @@ class CursorManager:
         self._pad.deinit()
         self._cursor.deinit()
         self._cursor = None
+        self._event = None
 
     def _is_deinited(self):
         """Checks if CursorManager object has been deinitd."""

--- a/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
+++ b/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
@@ -36,6 +36,7 @@ class CursorManager:
     def __init__(self, cursor):
         self._cursor = cursor
         self._is_clicked = False
+        self._pad_states = 0
         self._init_hardware()
 
     def __enter__(self):

--- a/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
+++ b/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
@@ -15,7 +15,7 @@ from keypad import ShiftRegisterKeys
 from adafruit_debouncer import Debouncer
 
 __version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE_Eddystone.git"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_CursorControl.git"
 
 
 # PyBadge

--- a/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
+++ b/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
@@ -101,7 +101,7 @@ class CursorManager:
         """Updates the cursor object."""
         event = self._pad.events.get()
         self._store_button_states(event)
-        self._check_cursor_movement(event)
+        self._check_cursor_movement()
         if self._is_clicked:
             self._is_clicked = False
         elif self._pad_states & (1 << self._pad_btns["btn_a"]):

--- a/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
+++ b/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
@@ -14,6 +14,9 @@ import analogio
 from keypad import ShiftRegisterKeys
 from adafruit_debouncer import Debouncer
 
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE_Eddystone.git"
+
 
 # PyBadge
 PYBADGE_BUTTON_LEFT = const(7)

--- a/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
+++ b/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
@@ -115,7 +115,7 @@ class CursorManager:
         reading = 0
         # pylint: disable=unused-variable
         if hasattr(board, "JOYSTICK_X"):
-            for sample in range(0, samples):
+            for _ in range(0, samples):
                 reading += self._joystick_x.value
             reading /= samples
         return reading

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["displayio", "gamepadshift"]
+autodoc_mock_imports = ["displayio"]
 
 
 intersphinx_mapping = {


### PR DESCRIPTION
Some additional infrastructure and linting changes as well, but most of the work is shifting (pun intended) away from gamepad's GamePadShift class to keypad's ShiftRegisterKeys.  I'm now storing the button states in `_pad_states` as a byte to keep track of the event changes, modified using the new method `_store_button_states()`.  This eliminates the need for `_check_cursor_movement` to take an input argument.  I've also changed the `PYBADGE` constants for represent bit indexes/event key numbers for easier bit manipulation.

I didn't have the hardware to test this, so I'd appreciate it if someone could!  Otherwise I should be able to get a Feather M4 Express and a shift register and try and mimic the behavior soon enough, if that will work.