### PR TITLE
CursorManager: Add support for Start and Select buttons for PyGamer.

### DIFF
--- a/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
+++ b/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
@@ -42,6 +42,7 @@ class CursorManager:
 
     :param Cursor cursor: The cursor object we are using.
     """
+
     # pylint: disable=too-many-instance-attributes
 
     def __init__(self, cursor: Cursor) -> None:
@@ -96,10 +97,12 @@ class CursorManager:
         elif hasattr(board, "JOYSTICK_X"):
             self._joystick_x = analogio.AnalogIn(board.JOYSTICK_X)
             self._joystick_y = analogio.AnalogIn(board.JOYSTICK_Y)
-            self._pad_btns = {"btn_a": PYBADGE_BUTTON_A,
-                              "btn_b": PYBADGE_BUTTON_B,
-                              "btn_select": PYBADGE_BUTTON_SELECT,
-                              "btn_start": PYBADGE_BUTTON_START}
+            self._pad_btns = {
+                "btn_a": PYBADGE_BUTTON_A,
+                "btn_b": PYBADGE_BUTTON_B,
+                "btn_select": PYBADGE_BUTTON_SELECT,
+                "btn_start": PYBADGE_BUTTON_START,
+            }
             # Sample the center points of the joystick
             self._center_x = self._joystick_x.value
             self._center_y = self._joystick_y.value

--- a/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
+++ b/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
@@ -92,6 +92,8 @@ class CursorManager:
                 "btn_down": PYBADGE_BUTTON_DOWN,
                 "btn_a": PYBADGE_BUTTON_A,
                 "btn_b": PYBADGE_BUTTON_B,
+                "btn_select": PYBADGE_BUTTON_SELECT,
+                "btn_start": PYBADGE_BUTTON_START,
             }
             self._pad_states = 0
         elif hasattr(board, "JOYSTICK_X"):

--- a/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
+++ b/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
@@ -42,6 +42,7 @@ class CursorManager:
 
     :param Cursor cursor: The cursor object we are using.
     """
+    # pylint: disable=too-many-instance-attributes
 
     def __init__(self, cursor: Cursor) -> None:
         self._cursor = cursor

--- a/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
+++ b/adafruit_cursorcontrol/cursorcontrol_cursormanager.py
@@ -31,6 +31,8 @@ PYBADGE_BUTTON_UP = const(6)
 PYBADGE_BUTTON_DOWN = const(5)
 PYBADGE_BUTTON_RIGHT = const(4)
 # PyBadge & PyGamer
+PYBADGE_BUTTON_SELECT = const(3)
+PYBADGE_BUTTON_START = const(2)
 PYBADGE_BUTTON_A = const(1)
 PYBADGE_BUTTON_B = const(0)
 
@@ -45,6 +47,8 @@ class CursorManager:
         self._cursor = cursor
         self._is_clicked = False
         self._is_alt_clicked = False
+        self._is_select_clicked = False
+        self._is_start_clicked = False
         self._pad_states = 0
         self._event = Event()
         self._init_hardware()
@@ -91,7 +95,10 @@ class CursorManager:
         elif hasattr(board, "JOYSTICK_X"):
             self._joystick_x = analogio.AnalogIn(board.JOYSTICK_X)
             self._joystick_y = analogio.AnalogIn(board.JOYSTICK_Y)
-            self._pad_btns = {"btn_a": PYBADGE_BUTTON_A, "btn_b": PYBADGE_BUTTON_B}
+            self._pad_btns = {"btn_a": PYBADGE_BUTTON_A,
+                              "btn_b": PYBADGE_BUTTON_B,
+                              "btn_select": PYBADGE_BUTTON_SELECT,
+                              "btn_start": PYBADGE_BUTTON_START}
             # Sample the center points of the joystick
             self._center_x = self._joystick_x.value
             self._center_y = self._joystick_y.value
@@ -109,17 +116,31 @@ class CursorManager:
 
     @property
     def is_clicked(self) -> bool:
-        """Returns True if the cursor button was pressed
+        """Returns True if the cursor A button was pressed
         during previous call to update()
         """
         return self._is_clicked
 
     @property
     def is_alt_clicked(self) -> bool:
-        """Returns True if the cursor button was pressed
+        """Returns True if the cursor B button was pressed
         during previous call to update()
         """
         return self._is_alt_clicked
+
+    @property
+    def is_select_clicked(self) -> bool:
+        """Returns True if the Select button was pressed
+        during previous call to update()
+        """
+        return self._is_select_clicked
+
+    @property
+    def is_start_clicked(self) -> bool:
+        """Returns True if the Start button was pressed
+        during previous call to update()
+        """
+        return self._is_start_clicked
 
     def update(self) -> None:
         """Updates the cursor object."""
@@ -135,6 +156,16 @@ class CursorManager:
             self._is_alt_clicked = False
         elif self._pad_states & (1 << self._pad_btns["btn_b"]):
             self._is_alt_clicked = True
+
+        if self._is_select_clicked:
+            self._is_select_clicked = False
+        elif self._pad_states & (1 << self._pad_btns["btn_select"]):
+            self._is_select_clicked = True
+
+        if self._is_start_clicked:
+            self._is_start_clicked = False
+        elif self._pad_states & (1 << self._pad_btns["btn_start"]):
+            self._is_start_clicked = True
 
     def _read_joystick_x(self, samples: int = 3) -> float:
         """Read the X analog joystick on the PyGamer.


### PR DESCRIPTION
Hi

I have been using  CursorControl with PyGamer for a personal projects and being quite fond of this library. Unfortunately,  there is no support for PyGamer's `Select` and `Start` buttons . This change makes it possible to check if either `Select` or `Start` button have been pressed. Implementation is similar to how buttons `A` or `B` states are handled.

I hope that this pull request would be useful for others as well.