### PR TITLE
Replace depreciated .show

### DIFF
--- a/examples/cursorcontrol_buttons_debounced.py
+++ b/examples/cursorcontrol_buttons_debounced.py
@@ -118,7 +118,7 @@ splash.append(start_button)
 splash.append(select_button)
 splash.append(a_button)
 splash.append(b_button)
-display.show(splash)
+display.root_group = splash
 
 while True:
     debounced_cursor.update()

--- a/examples/cursorcontrol_buttons_text.py
+++ b/examples/cursorcontrol_buttons_text.py
@@ -115,7 +115,7 @@ mouse_cursor = Cursor(display, display_group=splash)
 cursor = CursorManager(mouse_cursor)
 
 # show displayio group
-display.show(splash)
+display.root_group = splash
 
 prev_btn = None
 while True:

--- a/examples/cursorcontrol_custom_cursor.py
+++ b/examples/cursorcontrol_custom_cursor.py
@@ -28,7 +28,7 @@ mouse_cursor = Cursor(display, display_group=splash, bmp=bmp)
 cursor = CursorManager(mouse_cursor)
 
 # show displayio group
-display.show(splash)
+display.root_group = splash
 
 while True:
     cursor.update()

--- a/examples/cursorcontrol_simpletest.py
+++ b/examples/cursorcontrol_simpletest.py
@@ -20,7 +20,7 @@ mouse_cursor = Cursor(display, display_group=splash)
 cursor = CursorManager(mouse_cursor)
 
 # show displayio group
-display.show(splash)
+display.root_group = splash
 
 while True:
     cursor.update()


### PR DESCRIPTION
 fixes #37 
CursorControl still uses .show() as an attribute to make a cursor that was previously hidden, visible again.